### PR TITLE
docs: sentence case and remove mention of prototype from title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Trade and Investment Factsheets Prototype
+# Trade and investment factsheets
 
-This repository contains the source code for the <a href="https://trade-and-investment-factsheets.docs.trade.gov.uk/">Trade and Investment Factsheets Prototype</a>.
+This repository contains the source code for <a href="https://trade-and-investment-factsheets.docs.trade.gov.uk/">Trade and investment factsheets</a>.
 
 > [!IMPORTANT]  
 > This is prototype for testing purposes only. It exists to experiment with using the [Observable Framework](https://observablehq.com/framework) to publish dashboards of public data.


### PR DESCRIPTION
 We have the word "prototype" in a few other places, e.g. the "tag", so no need to push it in the titles