### PR TITLE
ci: avoid cancelling previews when cleaning up

### DIFF
--- a/.github/workflows/github-pages-tidy-preview.yml
+++ b/.github/workflows/github-pages-tidy-preview.yml
@@ -2,7 +2,6 @@ name: "GitHub pages: tidy up preview"
 
 concurrency:
   group: preview-${{ github.event.number }}
-  cancel-in-progress: true
 
 on:
   pull_request:


### PR DESCRIPTION
This should avoid the red failures on the commits, which would be misleading since nothing really is wrong