### PR TITLE
ci: avoid using sudo for installing packages

### DIFF
--- a/.github/workflows/github-pages-deploy-main.yml
+++ b/.github/workflows/github-pages-deploy-main.yml
@@ -34,8 +34,8 @@ jobs:
             ~/.cache/R/renv
       - name: Install R packages
         run: |
-          sudo Rscript -e 'options(warn = 2); install.packages("renv", repos="https://cloud.r-project.org")'
-          sudo Rscript -e 'options(warn = 2); renv::restore()'
+          Rscript -e 'options(warn = 2); install.packages("renv", repos="https://cloud.r-project.org")'
+          Rscript -e 'options(warn = 2); renv::restore()'
       - name: Install Javascript packages
         run: |
           npm ci

--- a/.github/workflows/github-pages-deploy-preview.yml
+++ b/.github/workflows/github-pages-deploy-preview.yml
@@ -37,8 +37,8 @@ jobs:
             ~/.cache/R/renv
       - name: Install R packages
         run: |
-          sudo Rscript -e 'options(warn = 2); install.packages("renv", repos="https://cloud.r-project.org")'
-          sudo Rscript -e 'options(warn = 2); renv::restore()'
+          Rscript -e 'options(warn = 2); install.packages("renv", repos="https://cloud.r-project.org")'
+          Rscript -e 'options(warn = 2); renv::restore()'
       - name: Install Javascript packages
         run: |
           npm ci


### PR DESCRIPTION
This should also mean that they get cached in the correct '~' directory