### PR TITLE
ci: cleanup old packages from cache when bumping versions in future

### DIFF
--- a/.github/workflows/github-pages-deploy-main.yml
+++ b/.github/workflows/github-pages-deploy-main.yml
@@ -29,9 +29,7 @@ jobs:
       - name: Fetch from / populate R package cache
         uses: actions/cache@v4
         with:
-          # No need to hash the lockfile for the cache key, because this is itself a cache that the
-          # below install step will pull a specific version of each package only if it needs to
-          key: renv-packages
+          key: r-${{ hashFiles('renv.lock') }}
           path: |
             ~/.cache/R/renv
       - name: Install R packages

--- a/.github/workflows/github-pages-deploy-preview.yml
+++ b/.github/workflows/github-pages-deploy-preview.yml
@@ -32,9 +32,7 @@ jobs:
       - name: Fetch from / populate R package cache
         uses: actions/cache@v4
         with:
-          # No need to hash the lockfile for the cache key, because this is itself a cache that the
-          # below install step will pull a specific version of each package only if it needs to
-          key: renv-packages
+          key: renv-packages-${{ hashFiles('renv.lock') }}
           path: |
             ~/.cache/R/renv
       - name: Install R packages


### PR DESCRIPTION
I realised that because the cache key doesn't change, then as new versions of packages are used, the old ones could end up hanging around in the cache "forever". So I think better to have a cache key that depends on the hash of the lockfile.