### PR TITLE
fix: properly fix tabs for production build

### DIFF
--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -21,7 +21,6 @@ export default {
   head: `
     <link rel="stylesheet" href="npm:govuk-frontend@5.8.0/dist/govuk/govuk-frontend.min.css">
     <link rel="stylesheet" href="style.css">
-    <script type="module" src="npm:govuk-frontend@5.8.0/dist/govuk/govuk-frontend.min.js"></script>
   `,
 
   // The path to the source root.
@@ -105,10 +104,6 @@ export default {
   </div>
 </div>
 <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
-<script type="module">
-  import { initAll } from "/_npm/govuk-frontend@5.8.0/dist/govuk/govuk-frontend.min.js"
-  initAll()
-</script>
 `,
   sidebar: false, // whether to show the sidebar
   // toc: true, // whether to show the table of contents

--- a/src/index.md
+++ b/src/index.md
@@ -5,6 +5,12 @@ toc: false
 theme: air
 ---
 
+<!-- Initialise govuk-frontend -->
+```js
+import { initAll } from 'npm:govuk-frontend@5.8.0/dist/govuk/govuk-frontend.min.js'
+initAll();
+````
+
 <!-- HTML combining all the above -->
 <div class="govuk-width-container"><div class="govuk-main-wrapper">
 <ul class="govuk-list">

--- a/src/partners/[country].md.jinja
+++ b/src/partners/[country].md.jinja
@@ -21,6 +21,12 @@ toc: false
 theme: air
 ---
 
+<!-- Initialise govuk-frontend -->
+```js
+import { initAll } from 'npm:govuk-frontend@5.8.0/dist/govuk/govuk-frontend.min.js'
+initAll();
+````
+
 <!-- Constants -->
 ```js
 const govuk_colour_palette = ["#F46A25", "#28A197", "#12436D", "#801650", "#3D3D3D", "#A285D1"];


### PR DESCRIPTION
To get the frontend Javascript properly initialised, including in the production build where files are stored wtih cache-busting hashes and so are not able to be determined in advance, the only way I've found is to have it in the .md files themselves. Slightly odd, but not the end of the world.